### PR TITLE
set clean timer duration is ttl

### DIFF
--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -458,7 +458,7 @@ func (dms *DiskMetricStore) doCleanUpInReguarInterval(timeToLive time.Duration) 
 	}
 	for {
 		dms.cleanupStaleValues(timeToLive)
-		timer1 := time.NewTimer(60 * time.Second)
+		timer1 := time.NewTimer(timeToLive)
 		<-timer1.C
 	}
 }


### PR DESCRIPTION
if clean timer duration is greater than ttl, data will remain more than ttl. so timer duration is  set  equal ttl